### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://fredrikoller.visualstudio.com/95cd29b8-9c75-4f8e-a311-eb8696086308/43ca003d-bb6f-4d1f-99a8-c1fccd2ed3a6/_apis/work/boardbadge/43d1fa28-1c1a-42b3-a130-ec8ff59f8f13)](https://fredrikoller.visualstudio.com/95cd29b8-9c75-4f8e-a311-eb8696086308/_boards/board/t/43ca003d-bb6f-4d1f-99a8-c1fccd2ed3a6/Microsoft.RequirementCategory)
 # redesigned-memory
 An experimental repo for me to learn Azure


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#208. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.